### PR TITLE
Add options.strict to ignore individual url parsing errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,15 +6,23 @@ const cheerio = require('cheerio');
 
 
 function modifyUrl(value, params, options) {
-  const parsedUrl = new URL(value, options.base);
-  Object.keys(params).forEach((key) => {
-    if (!parsedUrl.searchParams.has(key) || options.existing === 'overwrite') {
-      parsedUrl.searchParams.set(key, params[key]);
-    } else if (options.existing === 'append') {
-      parsedUrl.searchParams.append(key, params[key]);
+  try {
+    const parsedUrl = new URL(value, options.base);
+    Object.keys(params).forEach((key) => {
+      if (!parsedUrl.searchParams.has(key) || options.existing === 'overwrite') {
+        parsedUrl.searchParams.set(key, params[key]);
+      } else if (options.existing === 'append') {
+        parsedUrl.searchParams.append(key, params[key]);
+      }
+    });
+    return parsedUrl.toString()
+  } catch (err) {
+    if (options.strict) {
+      throw err;
+    } else {
+      return value;
     }
-  });
-  return parsedUrl.toString()
+  }
 }
 
 //options:
@@ -25,7 +33,8 @@ function haq(html, params, options) {
   options = options || {};
   defaults(options, {
     existing: 'append',
-    htmlparserOptions: {decodeEntities: false}
+    htmlparserOptions: {decodeEntities: false},
+    strict: true
   });
 
   const $ = cheerio.load(html, options.htmlparserOptions);
@@ -39,5 +48,3 @@ function haq(html, params, options) {
 
 
 module.exports = haq;
-
-

--- a/index.js
+++ b/index.js
@@ -6,23 +6,24 @@ const cheerio = require('cheerio');
 
 
 function modifyUrl(value, params, options) {
+  let parsedUrl;
   try {
-    const parsedUrl = new URL(value, options.base);
-    Object.keys(params).forEach((key) => {
-      if (!parsedUrl.searchParams.has(key) || options.existing === 'overwrite') {
-        parsedUrl.searchParams.set(key, params[key]);
-      } else if (options.existing === 'append') {
-        parsedUrl.searchParams.append(key, params[key]);
-      }
-    });
-    return parsedUrl.toString()
+    parsedUrl = new URL(value, options.base);
   } catch (err) {
-    if (options.strict) {
-      throw err;
-    } else {
+    if (err.code === 'ERR_INVALID_URL' && !options.strict) {
       return value;
+    } else {
+      throw err;
     }
   }
+  Object.keys(params).forEach((key) => {
+    if (!parsedUrl.searchParams.has(key) || options.existing === 'overwrite') {
+      parsedUrl.searchParams.set(key, params[key]);
+    } else if (options.existing === 'append') {
+      parsedUrl.searchParams.append(key, params[key]);
+    }
+  });
+  return parsedUrl.toString();
 }
 
 //options:


### PR DESCRIPTION
HAQ throws an error and halts when it encounters an invalid url. This is problematic when using email apis that use template placeholders, since one invalid url can prevent the whole template from being processed.

Example: `<a href='%unsubscribe_url%'>Unsubscribe</a>`

Added `strict:false` as an option to catch/ignore parsing errors at the url level, and leave invalid urls untouched while processing the rest of the file.